### PR TITLE
Add option to encode traveltime as RGBA png values.

### DIFF
--- a/src/main/resources/webapp/datapng.html
+++ b/src/main/resources/webapp/datapng.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>CommonSpace</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="GeoTrellis features demo.">
+    <meta name="author" content="Azavea">
+
+    <link href="css/bootstrap.css" rel="stylesheet">
+    <style type="text/css">
+    body {
+        padding-top: 60px;
+        padding-bottom: 40px;
+    }
+    .sidebar-nav {
+        padding: 9px 0;
+    }
+
+    .options {
+        float: right;
+    }
+
+    #opacitySlider {
+        float:right;
+        width:200px;
+        padding-left: 20px;
+    }
+
+    #colorChooser {
+        float:left;
+    }
+
+    @media (max-width: 980px) {
+        /* Enable use of floated navbar text */
+        .navbar-text.pull-right {
+            float: none;
+            padding-left: 5px;
+            padding-right: 5px;
+        }
+    }
+    </style>
+    <link href="css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="css/leaflet.css" rel="stylesheet">
+    <link href="css/leaflet.draw.css" rel="stylesheet">
+    <!--[if lte IE 8]>
+	<link rel="stylesheet" href="../dist/leaflet.ie.css" />
+	<![endif]-->
+    
+    <link href="css/jquery-ui.css" rel="stylesheet">
+    <link href="css/application.css" rel="stylesheet">
+
+    <script src="js/leaflet-src.js"></script>
+    <script src="js/leaflet.draw.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
+
+    <script src="js/geojson.js"></script>
+
+    <script src="js/jquery-1.9.1.min.js"></script>
+    <script src="js/jquery-ui-1.10.0.min.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+
+
+    <link href="css/jquery.dynatree.css" rel="stylesheet" type="text/css">
+    <script src="js/jquery.dynatree.min.js" type="text/javascript"></script>
+
+    <!--[if lt IE 9]>
+        <script src="../assets/js/html5shiv.js"></script>
+        <![endif]-->
+
+  </head>
+
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container-fluid">
+          <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="brand" id="page-title" href="#">CommonSpace</a>
+          <div class="nav-collapse collapse">
+            <ul class="nav pull-right">
+              <li><a href="#aboutModal" data-toggle="modal">About</a></li>
+            </ul>
+          </div><!--/.nav-collapse -->
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+      <div class="row-fluid">
+        <div class="span3">
+	  
+	  <ul class="nav nav-tabs">
+	    <li class="active"><a href="#browser" data-toggle="tab">Parameters</a></li>
+	    <li id="info-tab-link" style="display:none"><a href="#layer-info" data-toggle="tab">Layer Info</a></li>
+	  </ul>
+	  
+	  
+	  <div class="tab-content" id="left-pane">
+	    
+	    <div class="tab-pane active" id="browser">
+              <div id="timeSlider">
+                <span class="slider-label">Time of day</span>
+                <div id="time-slider"></div>
+              </div>              
+              <div id="durationSlider">
+                <span class="slider-label">Maximum Trip Duration</span>
+                <div id="duration-slider"></div>
+              </div>              
+	    </div>
+	    
+	    <div class="tab-pane" id="layer-info">
+	      <h2 id="layer-info-name"></h2>
+	      <div>
+                <dl id="layer-info-data" class="dl-horizontal"></dl>
+                <h5>Values:</h5>
+                <div id="valueViewer">
+                  <pclass=".lead" style="text-align: center;">
+                    Click on the layer to show values at that point.
+                  </p>
+                </div>
+              </div>
+	    </div>
+	    
+	  </div> <!--/tab-content -->
+	  
+        </div><!--/span-->
+
+	<div class="span9">
+	  <div class="pull-left">
+            <table>
+	      <tbody class="legend">
+		<tr>
+		  <td><img id="activeRamp" style="text-align: middle; min-width: 140px;"></img></td>
+		</tr>
+		<tr>
+		  <td><small>Low</small></td>
+		  <td style="position: absolute; margin-left: -28px;"><small>High</small></td>
+		</tr>
+              </tbody>
+            </table>
+	  </div>
+          <div class="options">
+            <ul id="colorChooser" class="nav nav-pills">
+              <li class="dropdown">
+                <a class="dropdown-toggle btn-primary btn-small" id="drop5" role="button" data-toggle="dropdown" href="#">
+                  Color Ramps
+                </a>
+                <ul id="color-ramp-menu" class="dropdown-menu" role="menu" aria-labelledby="drop5">
+                </ul>
+              </li>
+            </ul> <!-- /tabs -->
+            <div id="opacitySlider">
+              <span class="slider-label">Opacity</span>
+              <div id="opacity-slider"></div>
+            </div>
+          </div>
+	  <div id="map"></div>
+        </div><!--/map-->
+        
+      </div><!--/row-->
+
+    </div><!--/.fluid-container-->
+    
+    <!-- Modal -->
+    <div id="aboutModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+      <div class="modal-header">
+        <h3 id="myModalLabel">GeoTrellis</h3>
+      </div>
+      <div class="modal-body">
+        <p>Developed at <a href="http://www.azavea.com" target="_blank">Azavea</a>.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+      </div>
+    </div>
+    
+    <script src="js/datapng.js"></script>
+
+    <li id="colorRampTemplate" role="presentation" style="display:none">
+      <a role="menuitem" tabindex="-1" href="#" onclick="return false;">
+        <img role="menuitem" tabindex="-1" src="img/ramps/blue-to-orange.png"></img>
+      </a>
+    </li>
+
+  </body>
+</html>

--- a/src/main/resources/webapp/js/datapng.js
+++ b/src/main/resources/webapp/js/datapng.js
@@ -1,0 +1,284 @@
+var getLayer = function(url,attrib) {
+    return L.tileLayer(url, { maxZoom: 18, attribution: attrib });
+};
+
+var Layers = {
+    stamen: { 
+        toner:  'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',   
+        terrain: 'http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
+        watercolor: 'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+        attrib: 'Map data &copy;2013 OpenStreetMap contributors, Tiles &copy;2013 Stamen Design'
+    },
+    mapBox: {
+        azavea:     'http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
+        worldGlass:     'http://{s}.tiles.mapbox.com/v3/mapbox.world-glass/{z}/{x}/{y}.png',
+        worldBlank:  'http://{s}.tiles.mapbox.com/v3/mapbox.world-blank-light/{z}/{x}/{y}.png',
+        worldLight: 'http://{s}.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
+        attrib: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">MapBox</a>'
+    }
+};
+
+var map = (function() {
+    var selected = getLayer(Layers.mapBox.azavea,Layers.mapBox.attrib);
+
+    var baseLayers = {
+        "Azavea" : selected,
+        "World Light" : getLayer(Layers.mapBox.worldLight,Layers.mapBox.attrib),
+        "Terrain" : getLayer(Layers.stamen.terrain,Layers.stamen.attrib),
+        "Watercolor" : getLayer(Layers.stamen.watercolor,Layers.stamen.attrib),
+        "Toner" : getLayer(Layers.stamen.toner,Layers.stamen.attrib),
+        "Glass" : getLayer(Layers.mapBox.worldGlass,Layers.mapBox.attrib),
+        "Blank" : getLayer(Layers.mapBox.worldBlank,Layers.mapBox.attrib)
+    };
+
+    var m = L.map('map').setView([39.9886950160466,-75.1519775390625], 10);
+
+    selected.addTo(m);
+
+    m.lc = L.control.layers(baseLayers).addTo(m);
+
+    $('#map').resize(function() {
+        m.setView(m.getBounds(),m.getZoom());
+    });
+
+    return m;
+})();
+
+var travelTimes = (function() {
+    var mapLayer = null;
+    var vectorLayer = null;
+    var opacity = 0.7;
+
+    var duration = 10*60;
+    var time = 8*60*60;
+
+    return {
+        setOpacity : function(o) {
+            opacity = o;
+            if(mapLayer) { 
+                mapLayer.setOpacity(opacity); 
+            }
+        },
+        setTime : function(o) {
+            time = o;
+            travelTimes.update();
+        },
+        setDuration : function(o) {
+            duration = o;
+            travelTimes.update();
+        },
+        update : function() {
+            $.ajax({
+                url: 'gt/travelshed/request',
+                data: { latitude: startMarker.getLat(),
+                        longitude: startMarker.getLng(),
+                        time: time,
+                        duration: duration,
+                        colorRamp: colorRamps.getColorRamp(),
+                        format: 'image/png' },
+                dataType: "json",
+                success: function(data) {
+                    if (mapLayer) {
+                        map.lc.removeLayer(mapLayer);
+                        map.removeLayer(mapLayer);
+                        mapLayer = null;
+                    }
+                    if (vectorLayer) {
+                        map.lc.removeLayer(vectorLayer);
+                        map.removeLayer(vectorLayer);
+                        vectorLayer = null; 
+                    }
+//                    if(data.extent) {
+                        //extent = data.extent;
+                        //url = data.;
+                      if(data.token) {
+                          token = data.token
+//                        mapLayer = new L.ImageOverlay(url, extent);
+                        mapLayer = new L.TileLayer.WMS("gt/travelshed/wms", {
+                            token: token,
+                            // lat: startMarker.getLat(),
+                            // lng: startMarker.getLng(),
+                            // time: time,
+                            // duration: duration,
+                            // format: 'image/png',
+                            // transparent: true,
+                            colorRamp: colorRamps.getColorRamp(),
+                            attribution: 'Azavea'
+                        })
+
+
+                        mapLayer.setOpacity(opacity);
+                        mapLayer.addTo(map);
+                        map.lc.addOverlay(mapLayer, "Travel Times");
+                        $.ajax({
+                          url: 'gt/travelshed/json',
+                          data: { token: token },
+                          success: function(data) {
+                            vectorLayer = L.geoJson().addTo(map);
+                            vectorLayer.addData(data); 
+                          }
+                        })
+                        
+                    }
+                }
+            });
+        }
+    }
+})();
+
+var startMarker = (function() {
+    var lat = 40.0175
+    var lng = -75.059
+
+    var marker = L.marker([lat,lng], {
+        draggable: true 
+    }).addTo(map);
+    
+    marker.on('dragend', function(e) { 
+        lat = marker.getLatLng().lat;
+        lng = marker.getLatLng().lng;
+        travelTimes.update();
+    } );
+
+    return {
+        getMarker : function() { return marker; },
+        getLat : function() { return lat; },
+        getLng : function() { return lng; }
+    }
+})();
+
+var colorRamps = (function() {
+    var colorRamp = "blue-to-red";
+
+    var makeColorRamp = function(colorDef) {
+        var ramps = $("#color-ramp-menu");
+
+        var p = $("#colorRampTemplate").clone();
+        p.find('img').attr("src",colorDef.image);
+        p.click(function() {
+            $("#activeRamp").attr("src",colorDef.image);
+            colorRamps.setColorRamp(colorDef.key);
+        });
+        if(colorDef.key == colorRamp) {
+            $("#activeRamp").attr("src",colorDef.image);
+        }
+        p.show();
+        ramps.append(p);
+    }
+
+    return { 
+        bind: function() {
+            $.ajax({
+                url: 'gt/admin/colors',
+                dataType: 'json',
+                success: function(data) {
+                    _.map(data.colors, makeColorRamp)
+                }
+            });
+        },
+        setColorRamp: function(key) { 
+            colorRamp = key;
+            travelTimes.update();
+        },
+        getColorRamp: function(key) { 
+            return colorRamp;
+        },
+    };
+})();
+
+var opacitySlider = (function() {
+    var opacitySlider = $("#opacity-slider").slider({
+        value: 0.7,
+        min: 0,
+        max: 1,
+        step: .02,
+        slide: function( event, ui ) {
+            travelTimes.setOpacity(ui.value);
+        }
+    });
+
+    return {
+        setOpacity: function(o) {
+            opacitySlider.slider('value', o);
+        }
+    }
+})();
+
+var timeSlider = (function() {
+    var opacitySlider = $("#opacity-slider").slider({
+        value: 0.7,
+        min: 0,
+        max: 1,
+        step: .02,
+        slide: function( event, ui ) {
+            travelTimes.setOpacity(ui.value);
+        }
+    });
+
+    return {
+        setOpacity: function(o) {
+            opacitySlider.slider('value', o);
+        }
+    }
+})();
+
+var timeSlider = (function() {
+    var slider = $("#time-slider").slider({
+        value: 10*60*60,
+        min: 0,
+        max: 24*60*60,
+        step: 10,
+        change: function( event, ui ) {
+            travelTimes.setTime(ui.value);
+        }
+    });
+
+    return {
+        setTime: function(o) {
+            slider.slider('value', o);
+        }
+    }
+})();
+
+var durationSlider = (function() {
+    var slider = $("#duration-slider").slider({
+        value: 10*60,
+        min: 0,
+        max: 45*60,
+        step: 1,
+        change: function( event, ui ) {
+            travelTimes.setDuration(ui.value);
+        }
+    });
+
+    return {
+        setDuration: function(o) {
+            slider.slider('value', o);
+        }
+    }
+})();
+
+var setupSize = function() {
+    var bottomPadding = 10;
+
+    var resize = function(){
+        var pane = $('#left-pane');
+        var height = $(window).height() - pane.position().top - bottomPadding;
+        pane.css({'height': height +'px'});
+
+        var mapDiv = $('#map');
+        var height = $(window).height() - mapDiv.offset().top - bottomPadding;
+        mapDiv.css({'height': height +'px'});
+
+        map.invalidateSize();
+    };
+    resize();
+    $(window).resize(resize);
+};
+
+// On page load
+$(document).ready(function() {
+    setupSize();
+    colorRamps.bind();
+    travelTimes.update();
+});


### PR DESCRIPTION
The travel time in seconds is encoded in the color channels of the
generated png.  Disregarding the alpha channel, we encode the value
in base 255, using each channel for one digit.

Alpha channel is always set to 255 to avoid browser optimizations that

This commit also adds html and javascript for an in-process experiment
with animating travelsheds with the output of the service.
