### PR TITLE
Add Terraform website resources

### DIFF
--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -1,0 +1,62 @@
+resource "aws_cloudfront_distribution" "cdn" {
+  origin {
+    domain_name = "${aws_route53_record.origin.fqdn}"
+    origin_id   = "originTransitSite"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
+  }
+
+  enabled          = true
+  http_version     = "http2"
+  comment          = "GeoTrellis Transit (${var.environment})"
+  retain_on_delete = true
+
+  price_class = "${var.cdn_price_class}"
+
+  # The trailing period at the end of the name is stripped off to comply with CloudFront's CNAME policy.
+  aliases = ["transit.${replace(data.aws_route53_zone.external.name, "/.$/", "")}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "originTransitSite"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    compress               = false
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 300
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${data.terraform_remote_state.core.logs_bucket_id}.s3.amazonaws.com"
+    prefix          = "CloudFront/Transit/"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${var.ssl_certificate_arn}"
+    minimum_protocol_version = "TLSv1"
+    ssl_support_method       = "sni-only"
+  }
+}

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -1,0 +1,27 @@
+#
+# Public DNS resources
+#
+
+resource "aws_route53_record" "origin" {
+  zone_id = "${data.aws_route53_zone.external.id}"
+  name    = "transit-origin.${data.aws_route53_zone.external.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${lower(module.transit_ecs_service.lb_dns_name)}"
+    zone_id                = "${module.transit_ecs_service.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "cloudfront" {
+  zone_id = "${data.aws_route53_zone.external.id}"
+  name    = "transit.${data.aws_route53_zone.external.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.cdn.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.cdn.hosted_zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -1,0 +1,45 @@
+#
+# Website ALB security group resources
+#
+resource "aws_security_group_rule" "alb_transit_https_ingress" {
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${module.transit_ecs_service.lb_security_group_id}"
+}
+
+resource "aws_security_group_rule" "alb_transit_container_instance_all_egress" {
+  type      = "egress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${module.transit_ecs_service.lb_security_group_id}"
+  source_security_group_id = "${data.terraform_remote_state.core.container_instance_security_group_id}"
+}
+
+#
+# Container instance security group resources
+#
+resource "aws_security_group_rule" "container_instance_alb_transit_all_ingress" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${data.terraform_remote_state.core.container_instance_security_group_id}"
+  source_security_group_id = "${module.transit_ecs_service.lb_security_group_id}"
+}
+
+resource "aws_security_group_rule" "container_instance_alb_transit_all_egress" {
+  type      = "egress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${data.terraform_remote_state.core.container_instance_security_group_id}"
+  source_security_group_id = "${module.transit_ecs_service.lb_security_group_id}"
+}

--- a/deployment/terraform/remote-state.tf
+++ b/deployment/terraform/remote-state.tf
@@ -1,0 +1,13 @@
+data "terraform_remote_state" "core" {
+  backend = "s3"
+
+  config {
+    region = "${var.aws_region}"
+    bucket = "${var.remote_state_bucket}"
+    key    = "terraform/core/state"
+  }
+}
+
+data "aws_route53_zone" "external" {
+  zone_id = "${data.terraform_remote_state.core.public_hosted_zone_id}"
+}

--- a/deployment/terraform/task-definitions/transit.json
+++ b/deployment/terraform/task-definitions/transit.json
@@ -1,0 +1,15 @@
+[
+    {
+        "name": "gt-transit",
+        "image": "${transit_image}",
+        "cpu": 10,
+        "memory": 2048,
+        "essential": true,
+        "portMappings": [
+            {
+                "containerPort": 9999,
+                "hostPort": 0
+            }
+        ]
+    }
+]

--- a/deployment/terraform/transit.tf
+++ b/deployment/terraform/transit.tf
@@ -1,0 +1,45 @@
+#
+# ECS Resources
+#
+
+# Template for container definition, allows us to inject environment
+data "template_file" "ecs_transit_task" {
+  template = "${file("${path.module}/task-definitions/transit.json")}"
+
+  vars {
+    transit_image = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/gt-transit:${var.image_version}"
+  }
+}
+
+# Allows resource sharing among multiple containers
+resource "aws_ecs_task_definition" "transit" {
+  family                = "${var.environment}Transit"
+  container_definitions = "${data.template_file.ecs_transit_task.rendered}"
+}
+
+module "transit_ecs_service" {
+  source = "github.com/azavea/terraform-aws-ecs-web-service?ref=0.2.0"
+
+  name                = "Transit"
+  vpc_id              = "${data.terraform_remote_state.core.vpc_id}"
+  public_subnet_ids   = ["${data.terraform_remote_state.core.public_subnet_ids}"]
+  access_log_bucket   = "${data.terraform_remote_state.core.logs_bucket_id}"
+  access_log_prefix   = "ALB/Transit"
+  port                = "9999"
+  ssl_certificate_arn = "${var.ssl_certificate_arn}"
+
+  cluster_name                   = "${data.terraform_remote_state.core.container_instance_name}"
+  task_definition_id             = "${aws_ecs_task_definition.transit.family}:${aws_ecs_task_definition.transit.revision}"
+  desired_count                  = "${var.transit_ecs_desired_count}"
+  min_count                      = "${var.transit_ecs_min_count}"
+  max_count                      = "${var.transit_ecs_max_count}"
+  deployment_min_healthy_percent = "${var.transit_ecs_deployment_min_percent}"
+  deployment_max_percent         = "${var.transit_ecs_deployment_max_percent}"
+  container_name                 = "gt-transit"
+  container_port                 = "9999"
+  ecs_service_role_name          = "${data.terraform_remote_state.core.ecs_service_role_name}"
+  ecs_autoscale_role_arn         = "${data.terraform_remote_state.core.ecs_autoscale_role_arn}"
+
+  project     = "Geotrellis Transit"
+  environment = "${var.environment}"
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,50 @@
+variable "environment" {
+  default = "Production"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "Core infrastructure config bucket"
+}
+
+variable "aws_account_id" {
+  default     = "896538046175"
+  description = "Geotrellis Transit account ID"
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "image_version" {
+  type        = "string"
+  description = "Geotrellis Transit Image version"
+}
+
+variable "cdn_price_class" {
+  default = "PriceClass_200"
+}
+
+variable "ssl_certificate_arn" {
+  default = "arn:aws:acm:us-east-1:896538046175:certificate/a416c2af-00dd-4afd-8c71-dd32edefa839"
+}
+
+variable "transit_ecs_desired_count" {
+  default = "1"
+}
+
+variable "transit_ecs_min_count" {
+  default = "1"
+}
+
+variable "transit_ecs_max_count" {
+  default = "2"
+}
+
+variable "transit_ecs_deployment_min_percent" {
+  default = "100"
+}
+
+variable "transit_ecs_deployment_max_percent" {
+  default = "200"
+}

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+
+set -e
+
+if [[ -n "${GT_TRANSIT_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0") COMMAND OPTION[S]
+Deploy AWS infrastructure using Terraform.
+This script is only for use with Travis CI.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+        exit 0
+    fi
+    pushd "${DIR}/../"
+    ./scripts/cipublish
+    ./scripts/infra plan
+    ./scripts/infra apply
+    popd
+fi

--- a/scripts/infra
+++ b/scripts/infra
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${GT_TRANSIT_DEBUG}" ]]; then
+    set -x
+fi
+
+set -u
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0") COMMAND OPTION[S]
+Execute Terraform subcommands with remote state management.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        TERRAFORM_DIR="${DIR}/../deployment/terraform"
+        echo
+        echo "Attempting to deploy application version [${TRAVIS_COMMIT:0:7}]..."
+        echo "-----------------------------------------------------"
+        echo
+    fi
+
+    if [[ -n "${GT_TRANSIT_SETTINGS_BUCKET}" ]]; then
+        pushd "${TERRAFORM_DIR}"
+
+        case "${1}" in
+            plan)
+                rm -rf .terraform/ terraform.tfstate*
+                terraform init \
+                    -backend-config="bucket=${GT_TRANSIT_SETTINGS_BUCKET}" \
+                    -backend-config="key=terraform/transit/state"
+
+                terraform plan \
+                          -var="image_version=\"${TRAVIS_COMMIT:0:7}\"" \
+                          -var="remote_state_bucket=\"${GT_TRANSIT_SETTINGS_BUCKET}\"" \
+                          -out="${GT_TRANSIT_SETTINGS_BUCKET}.tfplan"
+                ;;
+            apply)
+                terraform apply "${GT_TRANSIT_SETTINGS_BUCKET}.tfplan"
+                ;;
+            *)
+                echo "ERROR: I don't have support for that Terraform subcommand!"
+                exit 1
+                ;;
+        esac
+
+        popd
+    else
+        echo "ERROR: No GT_TRANSIT_SETTINGS_BUCKET variable defined."
+        exit 1
+    fi
+fi

--- a/service/src/main/resources/webapp/css/application.css
+++ b/service/src/main/resources/webapp/css/application.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:100,300,400,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto:100,300,400,700);
 
 html,
 body {

--- a/service/src/main/resources/webapp/js/geotrellis-transit.js
+++ b/service/src/main/resources/webapp/js/geotrellis-transit.js
@@ -5,7 +5,9 @@ var GTT = (function() {
         var INITIAL_TIME = d.getTime() - d.setHours(0,0,0,0);
 
         /* To call the API properly both locally and in production */
-        var baseUrl = "http://" + window.location.hostname + ":9999/api";
+        baseUrl = window.location.hostname == "localhost" ?
+            "http://" + window.location.hostname + ":9999/api" :
+            "https://" + window.location.hostname + "/api";
 
         var viewCoords = [39.9886950160466,-75.1519775390625];
         var geoCodeLowerLeft = { lat: 39.7353312333975, lng: -75.4468831918069 };
@@ -48,17 +50,17 @@ var GTT = (function() {
 
         var layers = {
             stamen: {
-                toner:  'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',
-                terrain: 'http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
-                watercolor: 'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+                toner:  'https://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',
+                terrain: 'https://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
+                watercolor: 'https://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
                 attrib: 'Map data &copy;2013 OpenStreetMap contributors, Tiles &copy;2013 Stamen Design'
             },
             mapBox: {
-                azavea:     'http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
-                wnyc:       'http://{s}.tiles.mapbox.com/v3/jkeefe.map-id6ukiaw/{z}/{x}/{y}.png',
-                worldGlass:     'http://{s}.tiles.mapbox.com/v3/mapbox.world-glass/{z}/{x}/{y}.png',
-                worldBlank:  'http://{s}.tiles.mapbox.com/v3/mapbox.world-blank-light/{z}/{x}/{y}.png',
-                worldLight: 'http://{s}.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
+                azavea:     'https://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
+                wnyc:       'https://{s}.tiles.mapbox.com/v3/jkeefe.map-id6ukiaw/{z}/{x}/{y}.png',
+                worldGlass:     'https://{s}.tiles.mapbox.com/v3/mapbox.world-glass/{z}/{x}/{y}.png',
+                worldBlank:  'https://{s}.tiles.mapbox.com/v3/mapbox.world-blank-light/{z}/{x}/{y}.png',
+                worldLight: 'https://{s}.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
                 attrib: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">MapBox</a>'
             }
         };


### PR DESCRIPTION
# Overview

Add terraform resources for `transit.geotrellis.io`. This PR makes the following additions:
- Use the `terraform-aws-ecs-web-service` to define a service for the `gt-transit` container.
- Add a CloudFront distribution with the ECS service as an origin.
- Access core infrastructure remote state information with the `terraform_remote_state` data source
- Add firewall rules to allow communication between the Transit webservice ALB and the Container Instance, and allow HTTP(S) ingress to the ALB from the public internet.
- Add deployment STRTA
- Ensure all static resources are requested over HTTPS.

# Notes
Since the CloudFront SSL certificate is for `*.geotrellis.io`, the CloudFront distribution will fail SNI until DNS is cut over.

# Testing
- https://transit-origin.preview.geotrellis.io