### PR TITLE
Add CloudWatch logging to Transit service

### DIFF
--- a/deployment/terraform/task-definitions/transit.json
+++ b/deployment/terraform/task-definitions/transit.json
@@ -10,6 +10,14 @@
                 "containerPort": 9999,
                 "hostPort": 0
             }
-        ]
+        ],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "log${transit_environment}Transit",
+                "awslogs-region": "${transit_region}",
+                "awslogs-stream-prefix": "transit-demo"
+            }
+        }
     }
 ]

--- a/deployment/terraform/transit.tf
+++ b/deployment/terraform/transit.tf
@@ -7,7 +7,9 @@ data "template_file" "ecs_transit_task" {
   template = "${file("${path.module}/task-definitions/transit.json")}"
 
   vars {
-    transit_image = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/gt-transit:${var.image_version}"
+    transit_image       = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/gt-transit:${var.image_version}"
+    transit_environment = "${var.environment}"
+    transit_region      = "${var.aws_region}"
   }
 }
 
@@ -15,6 +17,14 @@ data "template_file" "ecs_transit_task" {
 resource "aws_ecs_task_definition" "transit" {
   family                = "${var.environment}Transit"
   container_definitions = "${data.template_file.ecs_transit_task.rendered}"
+}
+
+resource "aws_cloudwatch_log_group" "transit" {
+  name = "log${var.environment}Transit"
+
+  tags {
+    Environment = "${var.environment}"
+  }
 }
 
 module "transit_ecs_service" {


### PR DESCRIPTION
Route all ECS logs to the `logs${environment}ContainerInstance` CloudWatch logs group. 

# Testing
See the CloudWatch logs [here](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=logProductionContainerInstance)