### PR TITLE
Update HealthCheck endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ cache:
   - ${HOME}/.m2
   - ${HOME}/.sbt
 services: docker
+sudo: false
 env:
   global:
-  - TERRAFORM_VERSION=0.9.6
   - AWSCLI_VERSION=1.11.*
-  - DOCKER_COMPOSE_VERSION=1.13.*
+  - DOCKER_COMPOSE_VERSION=1.16.*
   - GT_TRANSIT_SETTINGS_BUCKET=geotrellis-site-production-config-us-east-1
   - AWS_DEFAULT_REGION=us-east-1
   - secure: S2aVBwFnTeS5RsR86rsG2695785vbMonUTyLrWp+TRZZmBCaeSBV9qGI3PWQ9fxucwfkvcIURmFdCyV3Byv8YxQBOSACKn1ivNYUMXQ7EyDejZd1P7Ujm229lJeNIHwln7CWkY9oET3XS21anRYqIr0HVirHlZkLjNiZ/n5Zcrk=
@@ -18,13 +18,8 @@ env:
 script:
 - mkdir -p ~/.local/bin
 - export PATH="~/.local/bin:$PATH"
-- pip install --user docker-compose==${DOCKER_COMPOSE_VERSION}
+- pip install --user docker-compose==${DOCKER_COMPOSE_VERSION} awscli==${AWSCLI_VERSION}
 - scripts/cibuild
-before_deploy:
-- wget -O terraform-${TERRAFORM_VERSION}.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-- unzip -d ~/.local/bin terraform-${TERRAFORM_VERSION}.zip
-- pip install --user awscli==${AWSCLI_VERSION}
-- rm terraform-${TERRAFORM_VERSION}.zip
 deploy:
   provider: script
   skip_cleanup: true
@@ -32,4 +27,4 @@ deploy:
   on:
     branch: master
 after_deploy:
-- rm deployment/terraform/${GT_TRANSIT_SETTINGS_BUCKET}.{tfvars,tfplan}
+- docker-compose -f docker-compose.ci.yml run --rm --entrypoint git terraform clean -fdx

--- a/deployment/terraform/transit.tf
+++ b/deployment/terraform/transit.tf
@@ -49,6 +49,7 @@ module "transit_ecs_service" {
   container_port                 = "9999"
   ecs_service_role_name          = "${data.terraform_remote_state.core.ecs_service_role_name}"
   ecs_autoscale_role_arn         = "${data.terraform_remote_state.core.ecs_autoscale_role_arn}"
+  health_check_path              = "/api/travelshed/wms?service=WMS&request=GetMap&version=1.1.1&layers=&styles=&format=image/jpeg&transparent=false&height=256&width=256&latitude=39.96238554917605&longitude=-75.16399383544922&time=43019&duration=3600&modes=walking&schedule=weekday&direction=departing&breaks=600,900,1200,1800,2400,3000,3600,4500,5400,7200&palette=0xF68481,0xFDB383,0xFEE085,0xDCF288,0xB6F2AE,0x98FEE6,0x83D9FD,0x81A8FC,0x8083F7,0x7F81BD&srs=EPSG:3857&bbox=-8384836.254770693,4862617.991389772,-8375052.315150191,4872401.931010273"
 
   project     = "Geotrellis Transit"
   environment = "${var.environment}"

--- a/deployment/terraform/transit.tf
+++ b/deployment/terraform/transit.tf
@@ -20,7 +20,8 @@ resource "aws_ecs_task_definition" "transit" {
 }
 
 resource "aws_cloudwatch_log_group" "transit" {
-  name = "log${var.environment}Transit"
+  name              = "log${var.environment}Transit"
+  retention_in_days = "30"
 
   tags {
     Environment = "${var.environment}"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,16 @@
+version: '2.1'
+services:
+  terraform:
+    image: "quay.io/azavea/terraform:latest"
+    volumes:
+      - ./:/usr/local/src
+      - ~/.aws:/root/.aws
+    environment:
+      - GT_TRANSIT_DEBUG=1
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_ECR_ENDPOINT=${AWS_ECR_ENDPOINT}
+      - TRAVIS_COMMIT=${TRAVIS_COMMIT}
+      - GT_TRANSIT_SETTINGS_BUCKET=${GT_TRANSIT_SETTINGS_BUCKET:-geotrellis-site-production-config-us-east-1}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -25,7 +25,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     pushd "${DIR}/../"
     ./scripts/update
     ./scripts/cipublish
-    ./scripts/infra plan
-    ./scripts/infra apply
+    docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
+    docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply
     popd
 fi


### PR DESCRIPTION
# Overview
Currently, the `ProductionTransit` ECS service is configured to use the default healthcheck path, `/`.  That path only returns static files, and isn't a good indicator about whether or not the backend service is up. This PR updates the ECS service `health_check_path` to match the one in [Panopta](https://my.panopta.com/report/ServerReport?server_id=937233#panel_1), which actually tests tests the backend.

Additionally, encapsulate CloudWatch's log retention period in terraform. It's currently set to 30 days.

Finally, add `docker-compose.ci.yml` for containerized deployments, and make sure to clean up CI after deployments.


# Testing
This change has already been deployed. The service hasn't been cycled out, so I think it's safe to say that the health check is working.

Closes #91 