### PR TITLE
Remove default value for ssl_certificate_arn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ deployment/ansible/roles/azavea.*
 deployment/terraform/.terraform
 *.tfplan
 *.tfstate*
+*.tfvars

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,42 @@
+# Amazon Web Services Deployment
+
+Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface (CLI)](http://aws.amazon.com/cli/).
+
+## Table of Contents
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `geotrellis`:
+
+```bash
+$ aws --profile geotrellis configure
+AWS Access Key ID [********************]:
+AWS Secret Access Key [********************]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+$ export GT_TRANSIT_SETTINGS_BUCKET="geotrellis-site-production-config-us-east-1"
+$ export AWS_PROFILE="geotrellis"
+# TRAVIS_COMMIT is the 7-digit SHA for the commit you want to deploy
+$ export TRAVIS_COMMIT=1a3b5c7
+$ docker-compose -f docker-compose.ci.yml -f docker-compose.ci.override.yml run --rm terraform ./scripts/infra plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+$ docker-compose -f docker-compose.ci.yml -f docker-compose.ci.override.yml run --rm terraform ./scripts/infra apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,5 +1,14 @@
 provider "aws" {
-  region = "us-east-1"
+  region  = "us-east-1"
+  version = "~> 1.27.0"
+}
+
+provider "template" {
+  version = "~> 1.0.0"
+}
+
+provider "terraform" {
+  version = "~> 1.0.0"
 }
 
 terraform {

--- a/deployment/terraform/transit.tf
+++ b/deployment/terraform/transit.tf
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_log_group" "transit" {
 }
 
 module "transit_ecs_service" {
-  source = "github.com/azavea/terraform-aws-ecs-web-service?ref=0.2.0"
+  source = "github.com/azavea/terraform-aws-ecs-web-service?ref=0.4.0"
 
   name                = "Transit"
   vpc_id              = "${data.terraform_remote_state.core.vpc_id}"
@@ -49,7 +49,6 @@ module "transit_ecs_service" {
   container_name                 = "gt-transit"
   container_port                 = "9999"
   ecs_service_role_name          = "${data.terraform_remote_state.core.ecs_service_role_name}"
-  ecs_autoscale_role_arn         = "${data.terraform_remote_state.core.ecs_autoscale_role_arn}"
   health_check_path              = "/api/travelshed/wms?service=WMS&request=GetMap&version=1.1.1&layers=&styles=&format=image/jpeg&transparent=false&height=256&width=256&latitude=39.96238554917605&longitude=-75.16399383544922&time=43019&duration=3600&modes=walking&schedule=weekday&direction=departing&breaks=600,900,1200,1800,2400,3000,3600,4500,5400,7200&palette=0xF68481,0xFDB383,0xFEE085,0xDCF288,0xB6F2AE,0x98FEE6,0x83D9FD,0x81A8FC,0x8083F7,0x7F81BD&srs=EPSG:3857&bbox=-8384836.254770693,4862617.991389772,-8375052.315150191,4872401.931010273"
 
   project     = "Geotrellis Transit"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -25,9 +25,7 @@ variable "cdn_price_class" {
   default = "PriceClass_200"
 }
 
-variable "ssl_certificate_arn" {
-  default = "arn:aws:acm:us-east-1:896538046175:certificate/a416c2af-00dd-4afd-8c71-dd32edefa839"
-}
+variable "ssl_certificate_arn" {}
 
 variable "transit_ecs_desired_count" {
   default = "1"

--- a/docker-compose.ci.override.yml
+++ b/docker-compose.ci.override.yml
@@ -1,0 +1,11 @@
+version: '2.1'
+services:
+  terraform:
+    image: "quay.io/azavea/terraform:0.10.8"
+    volumes:
+      - ~/.aws:/root/.aws
+    environment:
+      - GT_TRANSIT_DEBUG=1
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_PROFILE=${AWS_PROFILE:-geotrellis}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,7 +4,6 @@ services:
     image: "quay.io/azavea/terraform:0.10.8"
     volumes:
       - ./:/usr/local/src
-      - ~/.aws:/root/.aws
     environment:
       - GT_TRANSIT_DEBUG=1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   terraform:
-    image: "quay.io/azavea/terraform:latest"
+    image: "quay.io/azavea/terraform:0.10.8"
     volumes:
       - ./:/usr/local/src
       - ~/.aws:/root/.aws

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -34,7 +34,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                            -f docker-compose.test.yml build \
                            gt-transit
 
-            eval "$(aws ecr get-login)"
+            eval "$(aws ecr get-login --no-include-email)"
             docker tag "gt-transit:${VERSION}" \
                 "${AWS_ECR_ENDPOINT}/gt-transit:${VERSION}"
 

--- a/scripts/infra
+++ b/scripts/infra
@@ -34,11 +34,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         case "${1}" in
             plan)
                 rm -rf .terraform/ terraform.tfstate*
+                aws s3 cp "s3://${GT_TRANSIT_SETTINGS_BUCKET}/terraform/transit/terraform.tfvars" \
+                    "${GT_TRANSIT_SETTINGS_BUCKET}.tfvars"
+
                 terraform init \
                     -backend-config="bucket=${GT_TRANSIT_SETTINGS_BUCKET}" \
                     -backend-config="key=terraform/transit/state"
 
                 terraform plan \
+                          -var-file="${GT_TRANSIT_SETTINGS_BUCKET}.tfvars" \
                           -var="image_version=\"${TRAVIS_COMMIT:0:7}\"" \
                           -var="remote_state_bucket=\"${GT_TRANSIT_SETTINGS_BUCKET}\"" \
                           -out="${GT_TRANSIT_SETTINGS_BUCKET}.tfplan"


### PR DESCRIPTION
# Overview

This PR removes the default value for `ssl_certificate_arn` (which is now outdated) from `variables.tf`, and updates `scripts/infra` to use a .tfvars file to make it easier to override other defaults in the future. Also, bump ECS WebService module version to `0.4.0` and make some small fixes to the build pipeline.

## Changes
- Remove default value for `ssl_certficate_arn`. That value is now provided to terraform via a tfvars file.
- Add `docker-compose.ci.override.yml` for local deployments.
- Add `--no-include-email` flag to ECR login command
- Bump ECS WebService module to `0.4.0`. 

Fixes #94 
See azavea/operations#202

# Testing
- I deployed this PR from Travis. Build logs are [here](https://travis-ci.org/geotrellis/geotrellis-transit/jobs/403712003).
- Run `scripts/infra` according to the instructions in the new deployment README, ensure no changes are necessary.
```bash
$ export GT_TRANSIT_SETTINGS_BUCKET=geotrellis-site-production-config-us-east-1
$ export AWS_PROFILE=geotrellis
$ export TRAVIS_COMMIT=$(git rev-parse --short master)
$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
```
